### PR TITLE
Us 2 visitor navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,10 +10,12 @@
 
   <body>
     <nav class = "topnav">
-      <%= link_to "Register", "/register"%>
       <%= link_to "All Merchants", "/merchants"%>
       <%= link_to "All Items", "/items"%>
       <%= link_to "Cart: #{cart.total_items}", "/cart" %>
+      <%= link_to "Home", "/"%>
+      <%= link_to "Log In", "/login"%>
+      <%= link_to "Register", "/register"%>
     </nav>
     <% flash.each do |name, msg| %>
       <div class= "<%=name%>-flash">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/register', to: "users#new"
   post '/register', to: "users#create"
   get '/profile', to: 'users#show'
+  get '/login', to: 'sessions#new'
   #merchants
   get "/merchants", to: "merchants#index"
   get "/merchants/new", to: "merchants#new"

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe 'Site Navigation' do
   describe 'As a Visitor' do
+
     it "I see a nav bar with links to all pages" do
       visit '/merchants'
 
@@ -25,13 +26,62 @@ RSpec.describe 'Site Navigation' do
       within 'nav' do
         expect(page).to have_content("Cart: 0")
       end
+      click_link('Cart: 0')
+      expect(current_path).to eq('/cart')
 
       visit '/items'
 
       within 'nav' do
         expect(page).to have_content("Cart: 0")
       end
+    end
 
+    it "I can see a home page indicator on all pages" do
+      visit '/'
+
+      within 'nav' do
+        expect(page).to have_content("Home")
+      end
+      click_link('Home')
+      expect(current_path).to eq('/')
+
+      visit '/items'
+
+      within 'nav' do
+        expect(page).to have_content("Home")
+      end
+    end
+
+    it "I can see a login page indicator on all pages" do
+      visit '/'
+
+      within 'nav' do
+        expect(page).to have_content("Log In")
+      end
+      # click_link('Log In')
+      # expect(current_path).to eq('/sessions/new')
+
+      visit '/items'
+
+      within 'nav' do
+        expect(page).to have_content("Log In")
+      end
+    end
+
+    it "I can see a register page indicator on all pages" do
+      visit '/'
+
+      within 'nav' do
+        expect(page).to have_content("Register")
+      end
+      click_link('Register')
+      expect(current_path).to eq('/register')
+
+      visit '/items'
+
+      within 'nav' do
+        expect(page).to have_content("Register")
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] done

User Story 2, Visitor Navigation

As a visitor
I see a navigation bar
This navigation bar includes links for the following:
- [x] a link to return to the welcome / home page of the application ("/")
- [x] a link to browse all items for sale ("/items")
- [x] a link to see all merchants ("/merchants")
- [x] a link to my shopping cart ("/cart")
- [x] a link to log in ("/login")
- [x] a link to the user registration page ("/register")

- [x] Next to the shopping cart link I see a count of the items in my cart