### PR TITLE
Us 6 nav restrictions visitor

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: '/public/404' unless current_admin_user?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    
+  end
+end

--- a/app/controllers/merchant/base_controller.rb
+++ b/app/controllers/merchant/base_controller.rb
@@ -1,0 +1,7 @@
+class Merchant::BaseController < ApplicationController
+  before_action :require_merchant
+
+  def require_merchant
+    render file: '/public/404' unless current_merchant_user?
+  end
+end

--- a/app/controllers/merchant/dashboard_controller.rb
+++ b/app/controllers/merchant/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Merchant::DashboardController < Merchant::BaseController
+  def index
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,12 @@ Rails.application.routes.draw do
   get "/cart", to: "cart#show"
   delete "/cart", to: "cart#empty"
   delete "/cart/:item_id", to: "cart#remove_item"
+
+  namespace :admin do
+    get '/', to: 'dashboard#index'
+  end
+
+  namespace :merchant do
+    get '/', to: 'dashboard#index'
+  end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 
 RSpec.describe 'Site Navigation' do
   describe 'As a Visitor' do
-
     it "I see a nav bar with links to all pages" do
       visit '/merchants'
 
@@ -82,6 +81,17 @@ RSpec.describe 'Site Navigation' do
       within 'nav' do
         expect(page).to have_content("Register")
       end
+    end
+
+    it "I can't visit /admin, /merchant, or /profile" do
+      visit '/admin'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
+      visit '/merchant'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
+      visit '/profile'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
     end
   end
 


### PR DESCRIPTION
- [x] done

User Story 6, Visitor Navigation Restrictions

As a visitor
When I try to access any path that begins with the following, then I see a 404 error:
- [x] '/merchant'
- [x] '/admin'
- [x] '/profile'