### PR TITLE
Add tests that user cant visit /admin or /merchant, merchant cant vis…

### DIFF
--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe 'Site Navigation' do
         expect(page).to have_no_content("Merchant Dashboard")
       end
     end
+
+    it "I can't visit /admin or /merchant" do
+      user_1 = User.create!(name: "Batman",
+                            address: "Some dark cave 11",
+                            city: "Arkham",
+                            state: "CO",
+                            zip: "81301",
+                            email: 'batmansemail@email.com',
+                            password: "password",
+                            role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit '/admin'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
+      visit '/merchant'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+    end
   end
 
   describe 'As a merchant' do
@@ -150,6 +168,21 @@ RSpec.describe 'Site Navigation' do
         expect(page).to have_content('Logged in as Batman')
         expect(page).to have_content('Merchant Dashboard')
       end
+    end
+
+    it "I can't visit /admin" do
+      user_1 = User.create!(name: "Batman",
+                            address: "Some dark cave 11",
+                            city: "Arkham",
+                            state: "CO",
+                            zip: "81301",
+                            email: 'batmansemail@email.com',
+                            password: "password",
+                            role: 1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit '/admin'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
     end
   end
 


### PR DESCRIPTION
- [x] done

User Story 7, User Navigation Restrictions

As a default user
When I try to access any path that begins with the following, then I see a 404 error:
- [x] '/merchant'
- [x] '/admin'

User Story 8, Merchant Navigation Restrictions

As a merchant employee
When I try to access any path that begins with the following, then I see a 404 error:
- [x] '/admin'