### PR TITLE
Us 9 nav restrictions admin

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -8,6 +8,9 @@ class CartController < ApplicationController
 
   def show
     @items = cart.items
+    if current_admin_user?
+      render file: "/public/404"
+    end
   end
 
   def empty

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,5 +12,4 @@ class User < ApplicationRecord
   def duplicate_email?
     User.pluck(:email).include?(email)
   end
-
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -214,5 +214,23 @@ RSpec.describe 'Site Navigation' do
         expect(page).to have_no_content('Cart: 0')
       end
     end
+
+    it "I can't visit /merchant or /cart" do
+      user_1 = User.create!(name: "Batman",
+                            address: "Some dark cave 11",
+                            city: "Arkham",
+                            state: "CO",
+                            zip: "81301",
+                            email: 'batmansemail@email.com',
+                            password: "password",
+                            role: 2)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit '/merchant'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
+      visit '/cart'
+      expect(page).to have_content("The page you were looking for doesn't exist (404)")
+    end
   end
 end


### PR DESCRIPTION
- [x] done

User Story 9, Admin Navigation Restrictions

As an admin
When I try to access any path that begins with the following, then I see a 404 error:
- [x] '/merchant'
- [x] '/cart'