### PR TITLE
Add test for invalid log in

### DIFF
--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -71,4 +71,15 @@ RSpec.describe 'Logging In' do
     expect(page).to_not have_link('Log In')
     expect(page).to_not have_link('Register')
   end
+
+  it 'can not log in with invalid credentials and redirects to login page' do
+    visit '/login'
+
+    fill_in :email, with: "abc123@gmail.com"
+    fill_in :password, with: "abc123"
+    click_button 'Log In'
+
+    expect(current_path).to eq('/login')
+    expect(page).to have_content("Sorry, your credentials are bad.")
+  end
 end


### PR DESCRIPTION
-  [x] done

User Story 14, User cannot log in with bad credentials

As a visitor
When I visit the login page ("/login")
And I submit invalid information
Then I am redirected to the login page
And I see a flash message that tells me that my credentials were incorrect
I am NOT told whether it was my email or password that was incorrect