### PR TITLE
Us 27 profile order link

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,11 @@
 class OrdersController <ApplicationController
 
-  def new
+  def index
+    # binding.pry
+    @orders = Order.all
+  end
 
+  def new
   end
 
   def show

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,1 @@
+<h1>My Orders</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
     <%= "Email: #{current_user.email}" %><br>
 </ul></h3>
 
-<% if Order.all != []%>
+<% if Order.all != [] %>
   <%= link_to "My Orders", "/profile/orders" %>
 <% end %>
 <%= link_to "Edit Profile", "/profile/edit" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,5 +8,8 @@
     <%= "Email: #{current_user.email}" %><br>
 </ul></h3>
 
+<% if Order.all != []%>
+  <%= link_to "My Orders", "/profile/orders" %>
+<% end %>
 <%= link_to "Edit Profile", "/profile/edit" %>
 <%= link_to "Edit Password", "/password/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
   patch '/profile', to: 'users#update'
+  get '/profile/orders', to: 'orders#index'
 
   # password
   # resources :password, only: [:edit, :update]

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -98,4 +98,34 @@ describe 'As a user, when I visit user show' do
 
     expect(current_path).to eq('/profile')
   end
+
+  it 'I cannot see My Orders link if I have no orders.' do
+    visit '/profile'
+
+    expect(page).not_to have_link('My Orders')
+  end
+
+  it 'The My Orders link takes me to /profile/orders if I have orders.' do
+    order_1 = Order.create!(
+      name: 'Rodrigo',
+      address: '2 1st St.',
+      city: 'South Park',
+      state: 'CO',
+      zip: '84125'
+    )
+
+    order_2 = Order.create!(
+      name: 'Ogirdor',
+      address: '1 2nd St.',
+      city: 'Bloomington',
+      state: 'IN',
+      zip: '24125'
+    )
+
+    visit '/profile'
+    expect(page).to have_link('My Orders')
+    click_on 'My Orders'
+    expect(current_path).to eq('/profile/orders')
+    save_and_open_page
+  end
 end


### PR DESCRIPTION
Significant merge conflicts ahead

- [x] done

User Story 27, User Profile displays Orders link

As a registered user
When I visit my Profile page
And I have orders placed in the system
- [x] Then I see a link on my profile page called "My Orders"
- [x] When I click this link my URI path is "/profile/orders"