### PR TITLE
Us 28

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,5 @@
 class Order <ApplicationRecord
-  validates_presence_of :name, :address, :city, :state, :zip
+  validates_presence_of :name, :address, :city, :state, :zip, :status
 
   has_many :item_orders
   has_many :items, through: :item_orders
@@ -7,5 +7,9 @@ class Order <ApplicationRecord
 
   def grandtotal
     item_orders.sum('price * quantity')
+  end
+
+  def total_quantity_of_items
+    item_orders.sum(:quantity)
   end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,1 +1,0 @@
-<h1>My Orders</h1>

--- a/app/views/users_orders/index.html.erb
+++ b/app/views/users_orders/index.html.erb
@@ -1,4 +1,8 @@
 <h1>All orders for <%= @user.name %></h1>
+<p>Address: <%= @user.address%></p>
+<p>City: <%= @user.city%></p>
+<p>State: <%= @user.state%></p>
+<p>Zip: <%= @user.zip%></p>
 
 <ol>
   <% @orders.each do |order| %>

--- a/app/views/users_orders/index.html.erb
+++ b/app/views/users_orders/index.html.erb
@@ -7,12 +7,19 @@
 <ol>
   <% @orders.each do |order| %>
     <li class="shipping-address">
-      <p>Order Id: <%= order.id %></p>
+      <p>
+        Order Id: <%= link_to "#{order.id}", "/orders/#{order.id}" %>
+      </p>
       <p>Order Name: <%= order.name %></p>
       <p>Order Address: <%= order.address %></p>
       <p>Order City: <%= order.city %></p>
       <p>Order State: <%= order.state %></p>
       <p>Order Zip: <%= order.zip %></p>
+      <p>Order Created: <%= order.created_at %></p>
+      <p>Order Updated: <%= order.updated_at %></p>
+      <p>Order Grandtotal: <%= order.grandtotal %></p>
+      <p>Order Status: <%= order.status %></p>
+      <p>Order Quantity of Items: <%= order.total_quantity_of_items %></p>
     </li>
   <% end %>
 </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,6 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
   patch '/profile', to: 'users#update'
-  get '/profile/orders', to: 'orders#index'
-
   get '/profile/orders', to: 'users_orders#index'
 
   # password

--- a/db/migrate/20201031214614_add_status_to_orders.rb
+++ b/db/migrate/20201031214614_add_status_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :status, :string, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_31_193523) do
+ActiveRecord::Schema.define(version: 2020_10_31_214614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2020_10_31_193523) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "status", default: "pending"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/spec/features/orders/creation_spec.rb
+++ b/spec/features/orders/creation_spec.rb
@@ -39,17 +39,11 @@ RSpec.describe("Order Creation") do
     end
 
     it 'I can create a new order' do
-      name = "Bert"
-      address = "123 Sesame St."
-      city = "NYC"
-      state = "New York"
-      zip = 10001
-
-      fill_in :name, with: name
-      fill_in :address, with: address
-      fill_in :city, with: city
-      fill_in :state, with: state
-      fill_in :zip, with: zip
+      fill_in :name, with: @user.name
+      fill_in :address, with: @user.address
+      fill_in :city, with: @user.city
+      fill_in :state, with: @user.state
+      fill_in :zip, with: @user.zip
 
       click_button "Create Order"
 
@@ -58,11 +52,11 @@ RSpec.describe("Order Creation") do
       expect(current_path).to eq("/profile/orders")
 
       within '.shipping-address' do
-        expect(page).to have_content(name)
-        expect(page).to have_content(address)
-        expect(page).to have_content(city)
-        expect(page).to have_content(state)
-        expect(page).to have_content(zip)
+        expect(page).to have_content(@user.name)
+        expect(page).to have_content(@user.address)
+        expect(page).to have_content(@user.city)
+        expect(page).to have_content(@user.state)
+        expect(page).to have_content(@user.zip)
       end
 
       # within "#item-#{@paper.id}" do

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -106,7 +106,7 @@ describe 'As a user, when I visit user show' do
   end
 
   it 'The My Orders link takes me to /profile/orders if I have orders.' do
-    order_1 = Order.create!(
+    order_1 = @user.orders.create!(
       name: 'Rodrigo',
       address: '2 1st St.',
       city: 'South Park',
@@ -114,7 +114,7 @@ describe 'As a user, when I visit user show' do
       zip: '84125'
     )
 
-    order_2 = Order.create!(
+    order_2 = @user.orders.create!(
       name: 'Ogirdor',
       address: '1 2nd St.',
       city: 'Bloomington',
@@ -126,6 +126,5 @@ describe 'As a user, when I visit user show' do
     expect(page).to have_link('My Orders')
     click_on 'My Orders'
     expect(current_path).to eq('/profile/orders')
-    save_and_open_page
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -127,4 +127,38 @@ describe 'As a user, when I visit user show' do
     click_on 'My Orders'
     expect(current_path).to eq('/profile/orders')
   end
+
+  it 'I see all of my orders' do
+    order_1 = @user.orders.create!(
+      name: 'Rodrigo',
+      address: '2 1st St.',
+      city: 'South Park',
+      state: 'CO',
+      zip: '84125'
+    )
+
+    order_2 = @user.orders.create!(
+      name: 'Ogirdor',
+      address: '1 2nd St.',
+      city: 'Bloomington',
+      state: 'IN',
+      zip: '24125'
+    )
+
+    visit '/profile/orders'
+
+    expect(page).to have_link(order_1.id)
+    expect(page).to have_content(order_1.created_at)
+    expect(page).to have_content(order_1.updated_at)
+    expect(page).to have_content(order_1.status)
+    expect(page).to have_content(order_1.total_quantity_of_items)
+    expect(page).to have_content(order_1.grandtotal)
+
+    expect(page).to have_link(order_2.id)
+    expect(page).to have_content(order_2.created_at)
+    expect(page).to have_content(order_2.updated_at)
+    expect(page).to have_content(order_2.status)
+    expect(page).to have_content(order_2.total_quantity_of_items)
+    expect(page).to have_content(order_2.grandtotal)
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -7,6 +7,7 @@ describe Order, type: :model do
     it { should validate_presence_of :city }
     it { should validate_presence_of :state }
     it { should validate_presence_of :zip }
+    it { should validate_presence_of :status }
   end
 
   describe "relationships" do
@@ -30,7 +31,7 @@ describe Order, type: :model do
                             zip: "81301",
                             email: 'batmansemail@email.com',
                             password: "password")
-                            
+
       @order_1 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
 
 
@@ -39,6 +40,10 @@ describe Order, type: :model do
     end
     it 'grandtotal' do
       expect(@order_1.grandtotal).to eq(230)
+    end
+
+    it 'total_quantity_of_items' do
+      expect(@order_1.total_quantity_of_items).to eq(5)
     end
   end
 end


### PR DESCRIPTION
- [x] done

User Story 28, User Profile displays Orders

As a registered user
When I visit my Profile Orders page, "/profile/orders"
I see every order I've made, which includes the following information:
- the ID of the order, which is a link to the order show page
- the date the order was made
- the date the order was last updated
- the current status of the order
- the total quantity of items in the order
- the grand total of all items for that order