### PR TITLE
Us30

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,6 +33,13 @@ class OrdersController <ApplicationController
     end
   end
 
+  def update
+    order = Order.find(params[:id])
+    order.cancel_order
+    flash[:success] = "Your order was cancelled"
+    redirect_to profile_path
+  end
+
 
   private
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,4 +12,15 @@ class Order <ApplicationRecord
   def total_quantity_of_items
     item_orders.sum(:quantity)
   end
+
+  def cancel_order
+    self.update(status: 'cancelled')
+    item_orders.each do |order|
+      if order.status == 'fulfilled'
+       order.item.inventory += order.quantity
+     end   #we need to test to make sure this is this doing the thing 
+       order.status = 'unfulfilled'
+     end
+  end
+
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -22,6 +22,7 @@
       <td><p><%= @order.grandtotal %> </p></td>
     </tr>
   </table>
+  <p> <%= link_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %> </p>
 </section>
 
 <h1 align = "center">Order Info</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
   patch '/profile', to: 'users#update'
   get '/profile/orders', to: 'users_orders#index'
   get '/profile/orders/:id', to: 'orders#show'
+  patch '/profile/orders/:id', to: 'orders#update'
+
 
   # password
   # resources :password, only: [:edit, :update]

--- a/db/migrate/20201101194358_add_status_to_item_orders.rb
+++ b/db/migrate/20201101194358_add_status_to_item_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToItemOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :item_orders, :status, :string, default: 'pending'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_31_214614) do
+ActiveRecord::Schema.define(version: 2020_11_01_194358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_10_31_214614) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "pending"
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/spec/features/orders/cancel_spec.rb
+++ b/spec/features/orders/cancel_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe("Order Show Page") do
+  describe "As a registered user" do
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+
+      @user = User.create!(name: "Batman",
+                            address: "Some dark cave 11",
+                            city: "Arkham",
+                            state: "CO",
+                            zip: "81301",
+                            email: 'batmansemail@email.com',
+                            password: "password")
+
+      @order_1 = @user.orders.create!(
+        name: 'Rodrigo',
+        address: '2 1st St.',
+        city: 'South Park',
+        state: 'CO',
+        zip: '84125'
+      )
+
+      @item_order = ItemOrder.create!(item: @paper, order: @order_1, quantity: 2, price: (@paper.price * 2))
+
+      @order_2 = @user.orders.create!(
+        name: 'Ogirdor',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125'
+      )
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    it 'can cancel and order' do
+      visit "/profile/orders/#{@order_1.id}"
+      click_on "Cancel Order"
+      expect(page).to have_content("cancelled")
+      expect(current_path).to eq("/profile")
+      expect(page).to have_content("Your order was cancelled")
+    end
+  end
+  end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -38,12 +38,23 @@ describe Order, type: :model do
       @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
     end
-    it 'grandtotal' do
+    it '#grandtotal' do
       expect(@order_1.grandtotal).to eq(230)
     end
 
-    it 'total_quantity_of_items' do
+    it '#total_quantity_of_items' do
       expect(@order_1.total_quantity_of_items).to eq(5)
+
     end
+
+    it '#cancel_order' do
+       expect(@order_1.status).to eq('pending')
+       @order_1.cancel_order
+       expect(@order_1.status).to eq('cancelled')
+       expect(@order_1.item_orders.first.status).to eq('unfulfilled')
+     end
+
   end
+
+
 end


### PR DESCRIPTION
- [x] done

User Story 30, User cancels an order

As a registered user
When I visit an order's show page
I see a button or link to cancel the order
When I click the cancel button for an order, the following happens:
- [x] Each row in the "order items" table is given a status of "unfulfilled"
- [x] The order itself is given a status of "cancelled"
- [x] Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
- [x]  I am returned to my profile page
- [x] I see a flash message telling me the order is now cancelled
- [x] And I see that this order now has an updated status of "cancelled"