### PR TITLE
Us32

### DIFF
--- a/app/controllers/admin/users_dashboard_controller.rb
+++ b/app/controllers/admin/users_dashboard_controller.rb
@@ -1,5 +1,13 @@
 class Admin::UsersDashboardController < Admin::BaseController
+
   def show
     @user = User.find(params[:id])
   end
+
+  def update
+    order = Order.find(params[:order_id])
+    order.update(status: 'shipped')
+    redirect_to admin_path
+  end
+
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -8,5 +8,12 @@
   <p>Created at: <%= order.created_at %></p>
   <p>Updated at: <%= order.updated_at %></p>
   <p>Order Status: <%= order.status %></p>
+  <% if order.status == 'packaged' %>
+  <%= link_to 'Ship Order', "/admin/users/#{order.user.id}/orders/#{order.id}", method: :patch  %>
+  <% end %>
+  <% if order.status != 'shipped' %>
+  <p> Cancel Order  </p>
+  <% end %>
+  <!--  ^ this will be a link for admin cancel order -->
 </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/', to: 'dashboard#index'
     get '/users/:id', to:'users_dashboard#show'
+    patch '/users/:id/orders/:order_id', to:'users_dashboard#update'
   end
 
   namespace :merchant do

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe 'Admin dashboard' do
     it 'can see all orders info sorted by order status' do
 
       visit '/admin'
-
       expect(@order_3.name).to appear_before(@order_2.name)
       expect(@order_2.name).to appear_before(@order_1.name)
         within ".order-#{@order_1.id}" do
@@ -62,6 +61,17 @@ RSpec.describe 'Admin dashboard' do
           click_on "#{@order_1.user.name}"
         end
       expect(current_path).to eq("/admin/users/#{@user.id}")
+    end
+
+    it 'can ship an order' do
+      visit '/admin'
+      within ".order-#{@order_3.id}" do
+        click_on "Ship Order"
+        expect(page).to have_content('shipped')
+        expect(page).to_not have_content('Cancel Order')
+      end
+
+
     end
   end
 end


### PR DESCRIPTION
- [x] done

User Story 33, Admin can "ship" an order

As an admin user
When I log into my dashboard, "/admin"
- [x] Then I see any "packaged" orders ready to ship.
- [x] Next to each order I see a button to "ship" the order.
- [x] When I click that button for an order, the status of that order changes to "shipped"
- [x] And the user can no longer "cancel" the order.