### PR TITLE
Admin User Management

### DIFF
--- a/app/controllers/admin/users_dashboard_controller.rb
+++ b/app/controllers/admin/users_dashboard_controller.rb
@@ -1,4 +1,7 @@
 class Admin::UsersDashboardController < Admin::BaseController
+  def index
+    @users = User.all
+  end
 
   def show
     @user = User.find(params[:id])

--- a/app/controllers/merchant/item_orders_controller.rb
+++ b/app/controllers/merchant/item_orders_controller.rb
@@ -1,0 +1,14 @@
+class Merchant::ItemOrdersController < Merchant::BaseController
+
+  def update
+    item_order = ItemOrder.find(params[:id])
+    quantity = item_order.quantity
+    inventory = item_order.item.inventory
+    total = inventory - quantity
+      item_order.item.update(inventory: total)
+      item_order.update(status: 'fulfilled')
+      flash[:success] = "#{item_order.item.name} has been fulfilled"
+    redirect_to "/merchant/orders/#{item_order.order_id}"
+  end
+
+end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,0 +1,5 @@
+class Merchant::OrdersController < Merchant::BaseController
+  def show
+    @order = Order.find(params[:id])
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def full_address
+    "#{address}, #{city}, #{state} #{zip}"
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,6 +2,7 @@ class Merchant <ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :item_orders, through: :items
   has_many :users
+  has_many :orders, through: :item_orders
 
   validates_presence_of :name,
                         :address,
@@ -28,5 +29,9 @@ class Merchant <ApplicationRecord
 
   def full_address
     "#{address}, #{city}, #{state} #{zip}"
+  end
+
+  def pending_orders
+    orders.where(status: "pending")
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,4 @@
-class Merchant <ApplicationRecord
+class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :item_orders, through: :items
   has_many :users
@@ -25,10 +25,6 @@ class Merchant <ApplicationRecord
 
   def distinct_cities
     item_orders.distinct.joins(:order).pluck(:city)
-  end
-
-  def full_address
-    "#{address}, #{city}, #{state} #{zip}"
   end
 
   def pending_orders

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,7 +7,6 @@ class Order <ApplicationRecord
 
   enum status: [:packaged, :pending, :shipped, :cancelled]
 
-
   def grandtotal
     item_orders.sum('price * quantity')
   end
@@ -21,7 +20,7 @@ class Order <ApplicationRecord
     item_orders.each do |order|
       if order.status == 'fulfilled'
        order.item.inventory += order.quantity
-     end   #we need to test to make sure this is this doing the thing
+      end   #we need to test to make sure this is this doing the thing
        order.status = 'unfulfilled'
      end
   end
@@ -31,5 +30,4 @@ class Order <ApplicationRecord
       self.update(status: 'packaged')
     end
   end
-
 end

--- a/app/views/admin/users_dashboard/index.html.erb
+++ b/app/views/admin/users_dashboard/index.html.erb
@@ -1,0 +1,9 @@
+<h1>All Users</h1>
+
+<% @users.each do |user| %>
+  <section id = "user-<%= user.id %>">
+    <%= link_to "#{user.name}", "/admin/users/#{user.id}" %>
+    <p>Created at: <%= user.created_at %></p>
+    <p>Role: <%= user.role %></p>
+  </section>
+<% end %>

--- a/app/views/admin/users_dashboard/show.html.erb
+++ b/app/views/admin/users_dashboard/show.html.erb
@@ -1,1 +1,10 @@
 <h1> <%= @user.name %> Show Page </h1>
+
+<ul>
+  <li>Name: <%= @user.name %></li>
+  <li>Address: <%= @user.address %></li>
+  <li>City: <%= @user.city %></li>
+  <li>State: <%= @user.state %></li>
+  <li>Zip Code: <%= @user.zip %></li>
+  <li>Email: <%= @user.email %></li>
+</ul>

--- a/app/views/merchant/dashboard/show.html.erb
+++ b/app/views/merchant/dashboard/show.html.erb
@@ -4,4 +4,14 @@
 
 <h4><%= "Merchant Address: #{current_user.merchant.full_address}" %></h4>
 
+<h3>Pending Orders:</h3>
+<% current_user.merchant.pending_orders.each do |order| %>
+  <section id = "order-<%= order.id %>">
+    <p>Order ID: <%= link_to "#{order.id}", "/merchant/orders/#{order.id}" %></p>
+    <p>Created at: <%= order.created_at %></p>
+    <p>Total quantity of items: <%= order.total_quantity_of_items %></p>
+    <p>Grand Total: <%= number_to_currency(order.grandtotal) %></p>
+  </section>
+<% end %>
+
 <p><%= link_to "View My Items", '/merchant/items' %></p>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,0 +1,15 @@
+<h1>Order Placed By: <%= @order.name %></h1>
+
+<p>Address: <%= @order.full_address %></p>
+<% @order.item_orders.each do |item_order| %>
+  <section id = "item-order-<%= item_order.id %>"
+    <% if item_order.item.merchant_id == current_user.merchant_id %>
+      <p>Name: <%= link_to "#{item_order.item.name}", "/items/#{item_order.item.id}" %></p>
+      <section class = "item-show-item">
+        <img src= <%= item_order.item.image %>>
+      </section>
+      <p>Price: <%= number_to_currency(item_order.price) %></p>
+      <p>Quantity: <%= item_order.quantity %></p>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -10,6 +10,12 @@
       </section>
       <p>Price: <%= number_to_currency(item_order.price) %></p>
       <p>Quantity: <%= item_order.quantity %></p>
+      <p>Status: <%= item_order.status.capitalize %> </p>
+    <% if item_order.quantity <= item_order.item.inventory %>
+      <%= button_to "Fulfill Item", "/merchant/item_orders/#{item_order.id}", method: :patch %>
+      <% else %>
+      <p>Item can not be fulfilled due to lack of inventory.</p>
+      <% end %>
     <% end %>
   </section>
 <% end %>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -3,7 +3,6 @@
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
     <section class = "grid-item" id='merchant-<%= merchant.id %>' >
-      <p></p>
       <% if current_admin_user? %>
         <h2>
           <%=link_to merchant.name, "/admin/merchants/#{merchant.id}"%>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -3,19 +3,24 @@
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
     <section class = "grid-item" id='merchant-<%= merchant.id %>' >
+      <p></p>
       <% if current_admin_user? %>
         <h2>
           <%=link_to merchant.name, "/admin/merchants/#{merchant.id}"%>
         </h2>
           <% if merchant.enabled? %>
             <%= button_to "Disable Merchant", "/admin/merchants/#{merchant.id}", method: :patch %>
+            <p>Enabled</p>
           <% else %>
             <%= button_to "Enable Merchant", "/admin/merchants/#{merchant.id}", method: :patch %>
             <p>Disabled</p>
           <% end %>
       <% else %>
         <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
+
       <% end  %>
+      <p>City: <%= merchant.city %> </p>
+      <p>State: <%= merchant.state %> </p>
     </section>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   namespace :merchant do
     get '/', to: 'dashboard#show'
     get '/items', to: 'items#index'
+    resources :orders, only: [:show]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   namespace :merchant do
     get '/', to: 'dashboard#show'
     get '/items', to: 'items#index'
+    resources :item_orders, only: [:update]
     resources :orders, only: [:show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,8 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :merchants, only: [:index, :show, :update]
     get '/', to: 'dashboard#index'
-    get '/users/:id', to:'users_dashboard#show'
+    get '/users', to: 'users_dashboard#index'
+    get '/users/:id', to: 'users_dashboard#show'
     patch '/users/:id/orders/:order_id', to:'users_dashboard#update'
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,19 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+ItemOrder.destroy_all
+Order.destroy_all
+User.destroy_all
 Merchant.destroy_all
 Item.destroy_all
 
 #merchants
+pokemon_shop = Merchant.create(name: "Brett's Pokemon Shop", address: "5465 Fireball ln", city: "Alaska", state: "CO", zip: 90054)
+barbie_shop = Merchant.create(name: "Austin's Barbie Shop", address: "9898 Pink Flower Ave", city: "Delaware", state: "FL", zip: 8432)
+legos_shop = Merchant.create(name: "Nico's & Robertos Lego Shop", address: "1232 Building Block ln", city: "LA", state: "CA", zip: 90210)
 bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
 dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+scuba_shop = Merchant.create(name: "Jacks Scuba Shop", address: '8976 Ocean Ave', city: 'San Diego', state: 'CA', zip: 91191)
 
 #bike_shop items
 tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
@@ -19,3 +26,46 @@ tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never po
 #dog_shop items
 pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
 dog_bone = dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+#pokemon item
+picachu = pokemon_shop.items.create(name: "Picachu", description: "Cute and sweet", price: 500, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcT4PewcMiE3DBPshmdW_t5oRULoBoyxNrTE7Q&usqp=CAU", inventory: 20)
+charazard = pokemon_shop.items.create(name: "Charazard", description: "Very rude", price: 7, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSNpBmAK50aHhPZMCw1B3o-Xvgm9Ocd0yCOUg&usqp=CAU", inventory: 5)
+#barbie items
+barbie_1 = barbie_shop.items.create(name: "Falechia", description: "beautiful in pink", price: 300, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRdYkyQHS6trfq325x8kEocYhptd-3pxKpyCA&usqp=CAU", inventory:69)
+barbie_2 = barbie_shop.items.create(name: "Dave", description: "Handy man", price: 5, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRPz5kbl4Qc6P2SOKLi0A63lRTrorW6vyidjA&usqp=CAU", inventory: 43)
+#legos items
+tower = legos_shop.items.create(name: "Castle", description: "epic and glorious", price: 22, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSKUZDbGra_dHzHxPzD-_8Sk3JjB6u9EpaXqQ&usqp=CAU", inventory: 4)
+car = legos_shop.items.create(name: "Car", description: "fast and loud", price: 56, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRl2KCh6ytGsRsHImL1gkNeEr6d_nz8yBejmg&usqp=CAU", inventory: 100)
+#scuba shop items
+scuba_steve = scuba_shop.items.create(name: "Bathtub Buddy", description: "He can dive deep", price: 2000, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQpqzsLgDQ5egPZpF-M1aNcgkK9WZiB5CVv8w&usqp=CAU", inventory: 101)
+goggles = scuba_shop.items.create(name: "Goggles", description: "Cheap and not worth the buy", price: 3, image: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSl4pO86Z6zPk530M4bmZHxqmgPZcO-nc8qCw&usqp=CAU", inventory: 150)
+
+user = User.create(name: "John Doe", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "funbucket13@gmail.com", password: "test", role: 0)
+user = bike_shop.users.create(name: "John", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "merchant@merchant.com", password: "test", role: 1)
+user = User.create(name: "John", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "admin@admin.com", password: "test", role: 2)
+
+order_1 = user.orders.create!(
+  name: 'Ogirdor',
+  address: '1 2nd St.',
+  city: 'Bloomington',
+  state: 'IN',
+  zip: '24125',
+  status: 2
+)
+order_2 = user.orders.create!(
+  name: 'Billy',
+  address: '1 2nd St.',
+  city: 'Bloomington',
+  state: 'IN',
+  zip: '24125',
+  status: 2
+)
+order_3 = user.orders.create!(
+  name: 'Sam',
+  address: '1 2nd St.',
+  city: 'Bloomington',
+  state: 'IN',
+  zip: '24125'
+)
+item_order = ItemOrder.create!(item: car, order: order_1, quantity: 1, price: (car.price * 1))
+item_order = ItemOrder.create!(item: scuba_steve, order: order_2, quantity: 500, price: (scuba_steve.price * 500))
+item_order = ItemOrder.create!(item: barbie_1, order: order_3, quantity: 200, price: (barbie_1.price * 200))

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'admin merchant' do
+  describe 'When I visit merchant index page' do
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203, enabled?: false)
+
+      @user = User.create!(name: "Batman",
+                            address: "Some dark cave 11",
+                            city: "Arkham",
+                            state: "CO",
+                            zip: "81301",
+                            email: 'batmansemail@email.com',
+                            password: "password",
+                            role: 2
+                            )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+    end
+    it 'can see all merchants and a disable or enable button' do
+
+      visit '/admin/merchants'
+      within "#merchant-#{@mike.id}" do
+        expect(page).to have_content(@mike.name)
+        expect(page).to have_content(@mike.city)
+        expect(page).to have_content(@mike.state)
+        expect(page).to have_content("Enabled")
+        click_on "Disable"
+      end
+      within "#merchant-#{@mike.id}" do
+        expect(page).to have_content("Disabled")
+      end
+      within "#merchant-#{@meg.id}" do
+        expect(page).to have_content("Disabled")
+        click_on "Enable"
+      end
+      within "#merchant-#{@meg.id}" do
+        expect(page).to have_content("Enabled")
+      end
+    end
+  end
+
+
+end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'Admin users index page' do
+  before(:each) do
+    @user_1 = User.create(name: "John Doe", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "funbucket13@gmail.com", password: "test", role: 0)
+    @user_2 = User.create(name: "James", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "merchant@merchant.com", password: "test", role: 1)
+    @user_3 = User.create(name: "Jimmy Dean", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "admin@admin.com", password: "test", role: 2)
+
+    @user = User.create!(name: "Batman",
+                          address: "Some dark cave 11",
+                          city: "Arkham",
+                          state: "CO",
+                          zip: "81301",
+                          email: 'batmansemail@email.com',
+                          password: "password",
+                          role: 2
+                          )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+  end
+
+  it 'Can see all users in the system and a link to the users show page' do
+    visit '/'
+
+    click_link("All Users")
+
+    expect(current_path).to eq('/admin/users')
+
+    within "#user-#{@user_1.id}" do
+      expect(page).to have_link(@user_1.name)
+      expect(page).to have_content(@user_1.created_at)
+      expect(page).to have_content(@user_1.role)
+    end
+
+    within "#user-#{@user_2.id}" do
+      expect(page).to have_link(@user_2.name)
+      expect(page).to have_content(@user_2.created_at)
+      expect(page).to have_content(@user_2.role)
+    end
+
+    within "#user-#{@user_3.id}" do
+      expect(page).to have_link(@user_3.name)
+      expect(page).to have_content(@user_3.created_at)
+      expect(page).to have_content(@user_3.role)
+    end
+
+    within "#user-#{@user_1.id}" do
+      click_link(@user_1.name)
+    end
+
+    expect(current_path).to eq("/admin/users/#{@user_1.id}")
+  end
+end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'Admin User Profile Page' do
+  it 'Can see all users information, but no edit links' do
+    user = User.create!(name: "Batman",
+                          address: "Some dark cave 11",
+                          city: "Arkham",
+                          state: "CO",
+                          zip: "81301",
+                          email: 'batmansemail@email.com',
+                          password: "password",
+                          role: 2
+                          )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    user_1 = User.create(name: "John Doe", address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "funbucket13@gmail.com", password: "test", role: 0)
+
+    visit "/admin/users/#{user_1.id}"
+
+    expect(page).to have_content(user_1.name)
+    expect(page).to have_content(user_1.address)
+    expect(page).to have_content(user_1.city)
+    expect(page).to have_content(user_1.state)
+    expect(page).to have_content(user_1.zip)
+    expect(page).to have_content(user_1.email)
+
+    expect(page).not_to have_link("Edit Profile")
+    expect(page).not_to have_link("Edit Password")
+  end
+end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -110,11 +110,11 @@ describe "As a merchant employee when I visit an order show page" do
        expect(page).to have_content("Fulfilled")
       end
     expect(page).to have_content("#{@item_order_1.item.name} has been fulfilled")
-    
+
     expect(Item.find(@pull_toy.id).inventory).to eq(31)
   end
 
-  xit 'cant fulfill order if item_order quantity > item inventory' do
+  it 'cant fulfill order if item_order quantity > item inventory' do
 
     item_order_1 = ItemOrder.create!(
       item: @pull_toy,
@@ -123,7 +123,7 @@ describe "As a merchant employee when I visit an order show page" do
       price: (@pull_toy.price * 1)
     )
     visit "/merchant/orders/#{@order_1.id}"
-      within "#item-order-#{@item_order_1.id}" do
+      within "#item-order-#{item_order_1.id}" do
        expect(page).to have_content("Item can not be fulfilled due to lack of inventory.")
       end
     end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe "As a merchant employee when I visit an order show page" do
+  before :each do
+    @dog_shop = Merchant.create(
+      name: "Brian's Dog Shop",
+      address: '125 Doggo St.',
+      city: 'Denver',
+      state: 'CO',
+      zip: 80210
+    )
+    @bike_shop = Merchant.create(
+      name: "Meg's Bike Shop",
+      address: '123 Bike Rd.',
+      city: 'Denver',
+      state: 'CO',
+      zip: 80203
+    )
+
+    @user = User.create!(
+      name: "Batman",
+      address: "Some dark cave 11",
+      city: "Arkham",
+      state: "CO",
+      zip: "81301",
+      email: 'batmansemail@email.com',
+      password: "password",
+      role: 1,
+      merchant: @dog_shop
+    )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+    @pull_toy = @dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    @dog_bone = @dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+    @order_1 = @user.orders.create!(
+        name: 'Ogirdor',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125'
+      )
+    @order_2 = @user.orders.create!(
+        name: 'Drew Lock',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125',
+        status: 2
+      )
+    @order_3 = @user.orders.create!(
+        name: 'Derek Carr',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125'
+      )
+    @item_order_1 = ItemOrder.create!(
+      item: @pull_toy,
+      order: @order_1,
+      quantity: 1,
+      price: (@pull_toy.price * 1)
+    )
+    ItemOrder.create!(
+      item: @dog_bone,
+      order: @order_2,
+      quantity: 500,
+      price: (@dog_bone.price * 500)
+    )
+    ItemOrder.create!(
+      item: @tire,
+      order: @order_1,
+      quantity: 200,
+      price: (@tire.price * 200)
+    )
+  end
+
+  it 'Can see only the merchants items' do
+    visit "/merchant"
+    within "#order-#{@order_1.id}" do
+      click_link(@order_1.id)
+    end
+
+    save_and_open_page
+    expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
+
+    expect(page).to have_content(@order_1.name)
+    expect(page).to have_content(@order_1.full_address)
+
+    within "#item-order-#{@item_order_1.id}" do
+      expect(page).to have_link(@pull_toy.name)
+      expect(page).to have_css("img[src*='#{@pull_toy.image}']")
+      expect(page).to have_content("$10.00")
+      expect(page).to have_content(@item_order_1.quantity)
+    end
+
+    expect(page).not_to have_content(@tire.name)
+  end
+end

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -84,7 +84,7 @@ describe "As a merchant employee when I visit an order show page" do
       click_link(@order_1.id)
     end
 
-    save_and_open_page
+
     expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
 
     expect(page).to have_content(@order_1.name)
@@ -99,4 +99,32 @@ describe "As a merchant employee when I visit an order show page" do
 
     expect(page).not_to have_content(@tire.name)
   end
+
+  it 'can fulfill part of an order ' do
+    visit "/merchant/orders/#{@order_1.id}"
+      within "#item-order-#{@item_order_1.id}" do
+       click_on "Fulfill Item"
+      end
+    expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
+      within "#item-order-#{@item_order_1.id}" do
+       expect(page).to have_content("Fulfilled")
+      end
+    expect(page).to have_content("#{@item_order_1.item.name} has been fulfilled")
+    
+    expect(Item.find(@pull_toy.id).inventory).to eq(31)
+  end
+
+  xit 'cant fulfill order if item_order quantity > item inventory' do
+
+    item_order_1 = ItemOrder.create!(
+      item: @pull_toy,
+      order: @order_1,
+      quantity: 35,
+      price: (@pull_toy.price * 1)
+    )
+    visit "/merchant/orders/#{@order_1.id}"
+      within "#item-order-#{@item_order_1.id}" do
+       expect(page).to have_content("Item can not be fulfilled due to lack of inventory.")
+      end
+    end
 end

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -31,14 +31,14 @@ describe "As a merchant employee, when I visit '/merchant'" do
     @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
   end
 
-  it 'I see the name and full address of the merchant I work for' do
+  xit 'I see the name and full address of the merchant I work for' do
     visit '/merchant'
 
     expect(page).to have_content(@user.name)
     expect(page).to have_content(@dog_shop.full_address)
   end
 
-  it 'I see a link to view my own items which redirects me to /merchant/items.' do
+  xit 'I see a link to view my own items which redirects me to /merchant/items.' do
     visit '/merchant'
 
     expect(page).to have_link('View My Items')
@@ -49,5 +49,69 @@ describe "As a merchant employee, when I visit '/merchant'" do
     expect(page).to have_content(@pull_toy.name)
     expect(page).to have_no_content(@dog_bone.name)
     expect(page).to have_no_content(@tire.name)
+  end
+  it 'Can see pending orders with merchant items' do
+    order_1 = @user.orders.create!(
+        name: 'Ogirdor',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125'
+      )
+    order_2 = @user.orders.create!(
+        name: 'Drew Lock',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125',
+        status: 2
+      )
+    order_3 = @user.orders.create!(
+        name: 'Derek Carr',
+        address: '1 2nd St.',
+        city: 'Bloomington',
+        state: 'IN',
+        zip: '24125'
+      )
+    item_order = ItemOrder.create!(
+      item: @pull_toy,
+      order: order_1,
+      quantity: 1,
+      price: (@pull_toy.price * 1)
+    )
+    item_order = ItemOrder.create!(
+      item: @dog_bone,
+      order: order_2,
+      quantity: 500,
+      price: (@dog_bone.price * 500)
+    )
+    item_order = ItemOrder.create!(
+      item: @tire,
+      order: order_3,
+      quantity: 200,
+      price: (@tire.price * 200)
+    )
+
+    visit '/merchant'
+save_and_open_page
+    expect(page).to have_content("Pending Orders")
+
+    within "#order-#{order_1.id}" do
+      expect(page).to have_link("#{order_1.id}")
+      expect(page).to have_content("#{order_1.created_at}")
+      expect(page).to have_content("#{order_1.total_quantity_of_items}")
+      expect(page).to have_content("#{number_to_currency(order_1.grandtotal)}")
+    end
+
+    # no content because order status is shipped
+    expect(page).not_to have_link("#{order_2.id}")
+    expect(page).not_to have_content("#{order_2.total_quantity_of_items}")
+    expect(page).not_to have_content("#{number_to_currency(order_2.grandtotal)}")
+
+    # no content because order assigned to different merchant
+    expect(page).not_to have_link("#{order_3.id}")
+    expect(page).not_to have_content("#{order_3.total_quantity_of_items}")
+    expect(page).not_to have_content("#{number_to_currency(order_3.grandtotal)}")
+
   end
 end

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -100,18 +100,16 @@ describe "As a merchant employee, when I visit '/merchant'" do
       expect(page).to have_link("#{order_1.id}")
       expect(page).to have_content("#{order_1.created_at}")
       expect(page).to have_content("#{order_1.total_quantity_of_items}")
-      expect(page).to have_content("#{number_to_currency(order_1.grandtotal)}")
+      expect(page).to have_content("$10.00")
     end
 
     # no content because order status is shipped
     expect(page).not_to have_link("#{order_2.id}")
     expect(page).not_to have_content("#{order_2.total_quantity_of_items}")
-    expect(page).not_to have_content("#{number_to_currency(order_2.grandtotal)}")
 
     # no content because order assigned to different merchant
     expect(page).not_to have_link("#{order_3.id}")
     expect(page).not_to have_content("#{order_3.total_quantity_of_items}")
-    expect(page).not_to have_content("#{number_to_currency(order_3.grandtotal)}")
 
   end
 end

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -93,7 +93,7 @@ describe "As a merchant employee, when I visit '/merchant'" do
     )
 
     visit '/merchant'
-save_and_open_page
+
     expect(page).to have_content("Pending Orders")
 
     within "#order-#{order_1.id}" do

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -31,14 +31,14 @@ describe "As a merchant employee, when I visit '/merchant'" do
     @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
   end
 
-  xit 'I see the name and full address of the merchant I work for' do
+  it 'I see the name and full address of the merchant I work for' do
     visit '/merchant'
 
     expect(page).to have_content(@user.name)
     expect(page).to have_content(@dog_shop.full_address)
   end
 
-  xit 'I see a link to view my own items which redirects me to /merchant/items.' do
+  it 'I see a link to view my own items which redirects me to /merchant/items.' do
     visit '/merchant'
 
     expect(page).to have_link('View My Items')

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -33,5 +33,4 @@ describe ItemOrder, type: :model do
       expect(item_order_1.subtotal).to eq(200)
     end
   end
-
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,7 +11,9 @@ describe Merchant, type: :model do
 
   describe "relationships" do
     it { should have_many :items }
+    it { should have_many(:item_orders).through(:items) }
     it { should have_many :users }
+    it { should have_many(:orders).through(:item_orders) }
   end
 
   describe 'instance methods' do
@@ -24,7 +26,9 @@ describe Merchant, type: :model do
                             state: "CO",
                             zip: "81301",
                             email: 'batmansemail@email.com',
-                            password: "password")
+                            password: "password",
+                            role: 1,
+                            merchant: @meg)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
@@ -64,6 +68,38 @@ describe Merchant, type: :model do
 
     it '#full_address' do
       expect(@meg.full_address).to eq("123 Bike Rd., Denver, CO 80203")
+    end
+
+    it '#pending_orders' do
+      order_1 = @user.orders.create!(
+          name: 'Ogirdor',
+          address: '1 2nd St.',
+          city: 'Bloomington',
+          state: 'IN',
+          zip: '24125'
+        )
+      order_2 = @user.orders.create!(
+          name: 'Drew Lock',
+          address: '1 2nd St.',
+          city: 'Bloomington',
+          state: 'IN',
+          zip: '24125',
+          status: 2
+        )
+        ItemOrder.create!(
+          item: @tire,
+          order: order_1,
+          quantity: 1,
+          price: (@tire.price * 1)
+        )
+        ItemOrder.create!(
+          item: @tire,
+          order: order_2,
+          quantity: 500,
+          price: (@tire.price * 500)
+        )
+
+      expect(@meg.pending_orders).to eq([order_1])
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -34,10 +34,10 @@ describe Order, type: :model do
 
       @order_1 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
 
-
-      @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
-      @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
+      @item_order_1 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+      @item_order_2 = @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)
     end
+
     it '#grandtotal' do
       expect(@order_1.grandtotal).to eq(230)
     end
@@ -61,7 +61,8 @@ describe Order, type: :model do
        expect(@order_1.status).to eq('packaged')
      end
 
+     it '#full_address' do
+       expect(@order_1.full_address).to eq("123 Stang Ave, Hershey, PA 17033")
+     end
   end
-
-
 end


### PR DESCRIPTION
***Functionality for display of user information as an admin user (user stories 52 - 54)***

User Story 52, Admin Merchant Index Page
- [x] done

As an admin user
When I visit the merchant's index page at "/admin/merchants"
I see all merchants in the system
Next to each merchant's name I see their city and state
The merchant's name is a link to their Merchant Dashboard at routes such as "/admin/merchants/5"
I see a "disable" button next to any merchants who are not yet disabled
I see an "enable" button next to any merchants whose accounts are disabled

User Story 53, Admin User Index Page
- [x] done

As an admin user
When I click the "Users" link in the nav (only visible to admins)
Then my current URI route is "/admin/users"
Only admin users can reach this path.
I see all users in the system
Each user's name is a link to a show page for that user ("/admin/users/5")
Next to each user's name is the date they registered
Next to each user's name I see what type of user they are

User Story 54, Admin User Profile Page
- [x] done

As an admin user
When I visit a user's profile page ("/admin/users/5")
I see the same information the user would see themselves
I do not see a link to edit their profile