### PR TITLE
Password confirmation testing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,10 @@ class UsersController < ApplicationController
       flash[:notice] = "You are now registered and logged in!"
       redirect_to '/profile'
     elsif @user.duplicate_email?
-      flash[:notice] = "Email already exists, please choose a different email."
+      flash[:failure] = "Email already exists, please choose a different email."
+      render :new
+    elsif params[:password] != params[:password_confirmation]
+      flash[:failure] = "Password and Password Confirmation fields did not match."
       render :new
     else
       flash[:failure] = "You are missing required fields."

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 RSpec.describe 'User' do
   it "as a visitor I can register and see info on my show page" do
     visit '/'
@@ -70,5 +71,24 @@ RSpec.describe 'User' do
       expect(page).to have_field(:zip, with: "11111")
 
     expect(page).to have_content("Email already exists, please choose a different email.")
+  end
+
+  it 'shows a flash message if all fields except password_confirmation are filled correctly' do
+    visit '/register'
+
+    fill_in :name, with: "Ricky Bobby"
+    fill_in :address, with: "Victory Lane 1"
+    fill_in :city, with: "Dallas"
+    fill_in :state,  with: "Texas"
+    fill_in :zip, with: "11111"
+    fill_in :email, with: "shakenbake@gmail.com"
+    fill_in :password, with: "password"
+    fill_in :password_confirmation, with: "password123"
+
+    click_on "Create Account"
+
+    expect(current_path).to eq("/register")
+    expect(page).to have_content("Password and Password Confirmation fields did not match.")
+
   end
 end


### PR DESCRIPTION
This PR will:
* Add functionality for non-matching password and password_confirmation fields in new user form to display a unique message
* Add testing for this functionality

Resolves #3 